### PR TITLE
Repeat functions with "." in both normal and visual modes

### DIFF
--- a/ftplugin/votl.vim
+++ b/ftplugin/votl.vim
@@ -682,6 +682,7 @@ function! VotlInsertCheckbox() "{{{
         call VotlComputeHowMuchDone(s:VotlFindRootParent(line(".")))
     endif
     silent! call repeat#set("\<Plug>VotlInsertCheckbox")
+    silent! call visualrepeat#set("\<Plug>VotlInsertCheckbox")
 endfunction "}}}
 
 " Delete a checkbox if one exists
@@ -710,6 +711,7 @@ function! VotlInsertCheckboxPercent() "{{{
         "endif
     endif
     silent! call repeat#set("\<Plug>VotlInsertCheckboxPercent")
+    silent! call visualrepeat#set("\<Plug>VotlInsertCheckboxPercent")
 endfunction "}}}
 
 " Delete a checkbox percentage if one exists
@@ -735,6 +737,7 @@ function! VotlSwitchCheckbox() "{{{
     endif
     call VotlComputeHowMuchDone(s:VotlFindRootParent(line(".")))
     silent! call repeat#set("\<Plug>VotlSwitchCheckbox")
+    silent! call visualrepeat#set("\<Plug>VotlSwitchCheckbox")
 endfunction "}}}
 
 " Calculates proportion of already done work in the subtree

--- a/ftplugin/votl.vim
+++ b/ftplugin/votl.vim
@@ -681,6 +681,7 @@ function! VotlInsertCheckbox() "{{{
         execute "normal! ^i[_] \<esc>^"
         call VotlComputeHowMuchDone(s:VotlFindRootParent(line(".")))
     endif
+    silent! call repeat#set("\<Plug>VotlInsertCheckbox")
 endfunction "}}}
 
 " Delete a checkbox if one exists
@@ -708,6 +709,7 @@ function! VotlInsertCheckboxPercent() "{{{
             call VotlComputeHowMuchDone(s:VotlFindRootParent(line(".")))
         "endif
     endif
+    silent! call repeat#set("\<Plug>VotlInsertCheckboxPercent")
 endfunction "}}}
 
 " Delete a checkbox percentage if one exists
@@ -732,6 +734,7 @@ function! VotlSwitchCheckbox() "{{{
         execute "normal! ^lr_^"
     endif
     call VotlComputeHowMuchDone(s:VotlFindRootParent(line(".")))
+    silent! call repeat#set("\<Plug>VotlSwitchCheckbox")
 endfunction "}}}
 
 " Calculates proportion of already done work in the subtree
@@ -973,12 +976,15 @@ nmap <silent><buffer> <localleader>jt :call VotlGotoToday()<cr>
 
 " insert/delete a checkbox and/or percentage
 map <silent><buffer> <localleader>cb :call VotlInsertCheckbox()<cr>
+noremap <silent> <Plug>VotlInsertCheckbox :call VotlInsertCheckbox()<cr>
 map <silent><buffer> <localleader>cB :call VotlDeleteCheckbox()<cr>
 map <silent><buffer> <localleader>cp :call VotlInsertCheckboxPercent()<cr>
+noremap <silent> <Plug>VotlInsertCheckboxPercent :call VotlInsertCheckboxPercent()<cr>
 map <silent><buffer> <localleader>cP :call VotlDeleteCheckboxPercent()<cr>
 
 " switch the status of the box
 map <silent><buffer> <localleader>cx :call VotlSwitchCheckbox()<cr>
+noremap <silent> <Plug>VotlSwitchCheckbox :call VotlSwitchCheckbox()<cr>
 
 " calculate the proportion of work done on the subtree
 map <silent><buffer> <localleader>cu :call VotlComputeHowMuchDone(s:VotlFindRootParent(line(".")))<cr>


### PR DESCRIPTION
Requires:
repeat.vim: https://github.com/tpope/vim-repeat
visualrepeat: http://www.vim.org/scripts/script.php?script_id=3848

Register a few common commands to allow them to be repeated with ".".
